### PR TITLE
Bugfix/date casting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",
-        "mockery/mockery": "^1.5.1"
+        "mockery/mockery": "^1.5.1",
+        "phpunit/phpunit": "^9.6"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,11 @@
     ],
     "autoload": {
         "psr-4": {
-            "GearboxSolutions\\EloquentFileMaker\\": "src/",
+            "GearboxSolutions\\EloquentFileMaker\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Tests\\": "tests/"
         }
     },

--- a/src/Database/Eloquent/FMModel.php
+++ b/src/Database/Eloquent/FMModel.php
@@ -486,7 +486,7 @@ abstract class FMModel extends Model
         $value = $this->attributes[$key];
 
         // When writing dates the regular datetime format won't work, so we have to get JUST the date value
-        if ($this->isDateAttribute($key) && ($this->hasCast($key, ['date'] || $this->hasCast($key, ['custom_date']) || $this->hasCast($key, ['immutable_date'])))) {
+        if ($this->isDateAttribute($key) && $this->hasCast($key, ['date', 'custom_date', 'immutable_date'])) {
             $value = Arr::first(explode(' ', $value));
         }
 

--- a/tests/Unit/FMModelTest.php
+++ b/tests/Unit/FMModelTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit;
+
+use GearboxSolutions\EloquentFileMaker\Database\Eloquent\FMModel;
+use Tests\TestCase;
+
+class FMModelTest extends TestCase
+{
+    public function testDateAttributesAreCastCorrectly()
+    {
+        $model = new TestModel();
+
+        $now = now();
+
+        $model->DateField = $now;
+        $model->DateTimeField = $now;
+        $model->CustomDateTimeField = $now;
+
+        $this->assertEquals(
+            $now->format('n/j/Y'),
+            $model->getAttributesForFileMakerWrite()['DateField']
+        );
+
+        $this->assertEquals(
+            $now->format('n/j/Y g:i:s A'),
+            $model->getAttributesForFileMakerWrite()['DateTimeField']
+        );
+
+        $this->assertEquals(
+            $now->format('n/j/Y g:i:s A'),
+            $model->getAttributesForFileMakerWrite()['CustomDateTimeField']
+        );
+    }
+}
+
+/**
+ * @property \Illuminate\Support\Carbon $DateField
+ * @property \Illuminate\Support\Carbon $DateTimeField
+ * @property \Illuminate\Support\Carbon $CustomDateTimeField
+ */
+class TestModel extends FMModel
+{
+    protected $casts = [
+        'DateField' => 'date',
+        'DateTimeField' => 'datetime',
+        'CustomDateTimeField' => 'date:Y-m-d',
+    ];
+}

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 use GearboxSolutions\EloquentFileMaker\Services\FileMakerConnection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Mockery;
 use Tests\TestCase;
@@ -34,7 +35,7 @@ class FileMakerConnectionTest extends TestCase
         $this->assertEquals('filemaker', $connection->getConfig('name'));
         $this->assertEquals('tester', $connection->getConfig('database'));
 
-        $connection->setConnection('filemaker2');
+        $connection = DB::connection('filemaker2');
 
         $this->assertEquals('filemaker2', $connection->getConfig('name'));
         $this->assertEquals('tester2', $connection->getConfig('database'));
@@ -52,7 +53,7 @@ class FileMakerConnectionTest extends TestCase
 
     public function testDatabasePrefixIsAddedToLayoutNames()
     {
-        $connection = app(FileMakerConnection::class)->setConnection('prefix');
+        $connection = DB::connection('prefix');
 
         $this->assertEquals('dapi-', $connection->getLayout());
 
@@ -67,9 +68,9 @@ class FileMakerConnectionTest extends TestCase
     {
         $this->overrideDBHost();
         Http::fake([
-            'http://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200)
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200)
         ]);
-        $connection = app(FileMakerConnection::class)->setConnection('filemaker');
+        $connection = DB::connection('filemaker');
 
         $connection->login();
 
@@ -82,9 +83,9 @@ class FileMakerConnectionTest extends TestCase
     {
         $this->overrideDBHost();
         Http::fake([
-            'http://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200)
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200)
         ]);
-        $connection = app(FileMakerConnection::class)->setConnection('filemaker');
+        $connection = DB::connection('filemaker');
 
         $connection->login();
 


### PR DESCRIPTION
The 1.0.1 release broke our usage of this with a date (not datetime) cast and date field.

This PR fixes and simplifies the date-casting logic, adds tests, and fixes some other failing tests as well.