### PR TITLE
Passing null to str_starts_with is deprecated

### DIFF
--- a/src/Database/Eloquent/Concerns/FMHasAttributes.php
+++ b/src/Database/Eloquent/Concerns/FMHasAttributes.php
@@ -35,7 +35,7 @@ trait FMHasAttributes
         }
         // When writing dates the regular datetime format won't work, so we have to get JUST the date value
         // check the key's cast to see if it is cast to a date or custom date:format
-        $castType = $this->getCasts()[$key] ?? null;
+        $castType = $this->getCasts()[$key] ?? '';
         $isDate = $castType == "date" || str_starts_with($castType, 'date:');
         if ($isDate) {
             $value = Arr::first(explode(' ', $value));


### PR DESCRIPTION
str_starts_with no longer supports passing a null as the first parameter and we are setting the default to null instead of an empty string. This just sets the default for the cast type to an empty string.