### PR TITLE
Fixed script prerequest parameter

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -462,7 +462,7 @@ class FileMakerConnection extends Connection
             'script' => 'script',
             'scriptParam' => 'script.param',
             'scriptPrerequest' => 'script.prerequest',
-            'scriptPrerequestParam' => 'script.prerequets.param',
+            'scriptPrerequestParam' => 'script.prerequest.param',
             'scriptPresort' => 'script.presort',
             'scriptPresortParam' => 'script.presort.param',
             'offset' => 'offset',


### PR DESCRIPTION
Found this issue while using the script prerequest with parameter, throwing error as the mapping was mispelled