### PR TITLE
fix: FMBaseBuilder::portalData(): Argument #1 ($array) must be of typ…

### DIFF
--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -160,7 +160,7 @@ class FMEloquentBuilder extends Builder
         // Map the columns to FileMaker fields and strip out read-only fields/containers
         $fieldsToWrite = $this->model->getAttributesForFileMakerWrite();
 
-        $modifiedPortals = null;
+        $modifiedPortals = [];
         foreach ($fieldsToWrite as $key => $value) {
             // Check if the field is a portal (it should be an array if it is)
             if (is_array($value)) {
@@ -169,7 +169,7 @@ class FMEloquentBuilder extends Builder
             }
         }
 
-        if ($fieldsToWrite->count() > 0 || count($modifiedPortals ?? []) > 0) {
+        if ($fieldsToWrite->count() > 0 || count($modifiedPortals) > 0) {
             // we have some regular text fields to update
             // forward this request to a base query builder to execute the edit record request
             $response = $this->query->fieldData($fieldsToWrite->toArray())->portalData($modifiedPortals)->recordId($model->getRecordId())->editRecord();


### PR DESCRIPTION
Fixes issue after updating from 1.0.9 to 1.1.1
```
TypeError: GearboxSolutions\EloquentFileMaker\Database\Query\FMBaseBuilder::portalData(): Argument #1 ($array) must be of type array, null given, called in /app/xxx-api/vendor/gearbox-solutions/eloquent-filemaker/src/Database/Eloquent/FMEloquentBuilder.php on line 175

/app/xxx-api/vendor/gearbox-solutions/eloquent-filemaker/src/Database/Query/FMBaseBuilder.php:673
/app/xxx-api/vendor/gearbox-solutions/eloquent-filemaker/src/Database/Eloquent/FMEloquentBuilder.php:175
/app/xxx-api/vendor/gearbox-solutions/eloquent-filemaker/src/Database/Eloquent/FMModel.php:303
/app/xxx-api/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1131
...
```