### PR TITLE
Fix generic connection error

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -687,13 +687,15 @@ class FileMakerConnection extends Connection
                 $log_message = 'Connection Error: ' . $exception->getMessage();
             }
 
-            $contents = $response?->getBody()->getContents();
-            $contents = json_decode($contents, true);
-            if ($response && $response->getStatusCode() !== 200 && $contents !== null) {
-                $code = (int) Arr::first(Arr::pluck(Arr::get($contents, 'messages'), 'code'));
-                if ($code === 952 && $retries <= 1) {
-                    $refresh = true;
-                    $should_retry = true;
+            if ($response) {
+                $contents = $response->getBody()->getContents();
+                $contents = json_decode($contents, true);
+                if ($response->getStatusCode() !== 200 && $contents !== null) {
+                    $code = (int) Arr::first(Arr::pluck(Arr::get($contents, 'messages'), 'code'));
+                    if ($code === 952 && $retries <= 1) {
+                        $refresh = true;
+                        $should_retry = true;
+                    }
                 }
             }
 

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -687,7 +687,7 @@ class FileMakerConnection extends Connection
                 $log_message = 'Connection Error: ' . $exception->getMessage();
             }
 
-            $contents = $response->getBody()->getContents();
+            $contents = $response?->getBody()->getContents();
             $contents = json_decode($contents, true);
             if ($response && $response->getStatusCode() !== 200 && $contents !== null) {
                 $code = (int) Arr::first(Arr::pluck(Arr::get($contents, 'messages'), 'code'));


### PR DESCRIPTION
The $response variable is not checked before method getBody() is called 
It happens to me when working on a local environment without an internet connection to the server. The $response variable is null and it crashes without generating a specific exception.

This small fix allows the program to continue and finally returns a ConnectionException